### PR TITLE
Optimize performance of resolution changing

### DIFF
--- a/sparkle.js
+++ b/sparkle.js
@@ -5,6 +5,7 @@ window.onload = function() {
   var pixelsPerWidth = resolution.value;
   var pixelsPerHeight = resolution.value;
   var pixels = [];
+  var imageData = null;
   var isAnimating = false;
   var animationTimeout, animationFrame;
 
@@ -22,15 +23,23 @@ window.onload = function() {
   resetState();
 
   function displayPixelatedImage() {
+    if(!canvas.width || !canvas.height) {
+      return;
+    }
+
     pixelateCanvasImage();
 
     var pixelColors = getPixelColors();
 
     // Remove the previous render and redisplay the new image.
     container.innerHTML = '';
+    var fragment = document.createDocumentFragment();
     for (var i = 0; i < pixelColors.length; i++) {
-      pixels.push(drawPixel(pixelColors[i], canvas.width / pixelsPerWidth, canvas.height / pixelsPerHeight));
+      var pixel = drawPixel(pixelColors[i], canvas.width / pixelsPerWidth, canvas.height / pixelsPerHeight);
+      pixels.push(pixel);
+      fragment.appendChild(pixel);
     }
+    container.appendChild(fragment);
   }
 
   function drawPixel(rgba, size) {
@@ -39,7 +48,6 @@ window.onload = function() {
     pixel.style.width = pixel.style.height = size + 'px';
 
     pixel.style.backgroundColor = rgba;
-    container.appendChild(pixel);
     return pixel;
   }
 
@@ -50,6 +58,7 @@ window.onload = function() {
     ctx.drawImage(canvas,
                  0, 0, pixelsPerWidth, pixelsPerHeight, /* source */
                  0, 0, canvas.width, canvas.height /* dest */);
+    imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
   }
 
   function getPixelColors() {
@@ -58,16 +67,18 @@ window.onload = function() {
               ',' + data[2] + ',' + data[3] + ')';
     }
 
-    var colors = []
+    var colors = [];
+    var widthRatio = canvas.width / pixelsPerWidth;
+    var heightRatio = canvas.height / pixelsPerHeight;
 
     // How many original pixels we have in a "drawn" final pixel.
     for (var i = 0; i < pixelsPerWidth; i++) {
       for (var j = 0; j < pixelsPerHeight; j++) {
-        var x = canvas.width / pixelsPerWidth * i + 1;
-        var y = canvas.height / pixelsPerHeight * j + 1;
+        var x = Math.round(widthRatio * i + 1) * 4;
+        var y = Math.round(heightRatio * j + 1) * canvas.width * 4;
 
-        var pixel = ctx.getImageData(x, y, 1, 1);
-        var rgba = getRGBA(pixel.data);
+        var pixel = [imageData.data[y + x], imageData.data[y + x + 1], imageData.data[y + x + 2], imageData.data[y + x + 3]];
+        var rgba = getRGBA(pixel);
 
         colors.push(rgba);
       }


### PR DESCRIPTION
✨ Fantastic tool ✨ Congrats!

For some reason\* I _had_ to find out why changing resolution gets slower with every click and see if I can improve it. Turns out I can!
- DevTools pointed out that `getImageData` calls are quite expensive, so I replaced per-pixel calls with a single per-image call
- Appending pixels to the DOM was also a (much smaller) bottleneck, so I changed it a bit to use DocumentFragment

You can give it a try [here](https://kdzwinel.github.io/sparkle/).

`*` I have to work on something else, so my brain does everything to sabotage that
